### PR TITLE
Fix: Updates the Readme CLI to v3 for Github Actions

### DIFF
--- a/.github/workflows/readme.yaml
+++ b/.github/workflows/readme.yaml
@@ -3,13 +3,18 @@ on:
   push:
     branches:
       - main
+      - fix/github-actions
 jobs:
-  build:
+  sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: readmeio/github-readme-sync@v2
+      - name: Checkout this repo
+        uses: actions/checkout@v3
+
+      # Run GitHub Action to sync OpenAPI file at [path-to-file.json]
+      - name: GitHub Action
+        # We recommend specifying a fixed version, i.e. @7.5.0
+        # Docs: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions
+        uses: readmeio/rdme@7.5.0
         with:
-          readme-oas-key: ${{ secrets.README_OAS_KEY }}
-          oas-file-path: './openapi.yaml'
-          api-version: 'v2.0.1'
+          rdme: openapi ./openapi.yaml --key=${{ secrets.README_OAS_KEY }} --id=${{ secrets.README_API_DEFINITION_ID }}

--- a/.github/workflows/readme.yaml
+++ b/.github/workflows/readme.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - fix/github-actions
 jobs:
   sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Overview

This PR updates the GitHub Action config to use the new v3 Readme CLI to deploy changes to the openapi config.