### PR TITLE
Removed the project contact from the update project endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -525,8 +525,6 @@ paths:
                                     type: array
                                     items:
                                         $ref: '#/components/schemas/Coordinate'
-                                primary_contact:
-                                  $ref: '#/components/schemas/ProjectContactRequest'
             operationId: updateProject
             tags:
                 - Projects


### PR DESCRIPTION
### Overview

We don't support updating a project contact from the API. This PR removes it from the spec on the `updateProject` endpoint.