### PR TITLE
Add size limit to Upload Document attachment description

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1617,7 +1617,7 @@ paths:
                                             example: "test.txt"
                                         attachment:
                                             type: string
-                                            description: base64 encoded file contents with 30 MB limit
+                                            description: Base64 encoded file contents with 30 MB limit
                                             example: "VGVzdAo="
             responses:
                 "201":

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1617,7 +1617,7 @@ paths:
                                             example: "test.txt"
                                         attachment:
                                             type: string
-                                            description: base64 encoded file contents
+                                            description: base64 encoded file contents with 30 MB limit
                                             example: "VGVzdAo="
             responses:
                 "201":


### PR DESCRIPTION
### Description
We had a developer reach out asking about file size limits when uploading a document. The limit for uploads using the web app are 100 MB. This is documented [here](https://help.companycam.com/en/articles/8345636-how-to-upload-and-use-project-documents). This is something that we'll want to dig into and address at a later time, but for now the best solution is to communicate better. 

### Reason
![image](https://github.com/user-attachments/assets/de50c8a1-2f6c-46ae-8964-5eb43e3afac8)

