### PR TITLE
Fix - add an s to photo description endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2386,7 +2386,7 @@ paths:
                                 $ref: "#/components/schemas/Error"
                             example:
                                 errors: ["An unexpected error occurred"]
-    /photos/{photo_id}/description:
+    /photos/{photo_id}/descriptions:
         post:
             summary: "Update Photo Description"
             operationId: updatePhotoDescription


### PR DESCRIPTION
# Description
Must have been a typo when we added this endpoint. 


# Reason
A user reached out and was confused by why they were getting 404's 