### PR TITLE
update schema for photo description. 

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2405,12 +2405,10 @@ paths:
                 content:
                     "application/json":
                         schema:
+                            type: object
                             properties:
-                                photo:
-                                    type: object
-                                    properties:
-                                        description:
-                                            type: string
+                                description:
+                                    type: string
             responses:
                 "201":
                     description: "The updated photo"


### PR DESCRIPTION
We didn't need to include the photo object as part of the schema. 