### PR TITLE
Added restricted role option for create user and description

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -214,6 +214,9 @@ paths:
                                             type: string
                                         password:
                                             type: string
+                                        user_role:
+                                            type: string
+                                            description: "Role for the user. Allowed values: standard (default), restricted"
             responses:
                 "201":
                     description: "The created user"


### PR DESCRIPTION
Added documentation for the expanded Create User Payload. 

A dev user requested this and we implemented it this morning. We need the documentation to represent all of that so we get loads of users added. 

Note:
It may be good to follow up with adding this to the update user  endpoint as well. I could see that being the next follow up request, but this is fine for now. 