### PR TITLE
PLATB-38: Cursor Pagination on Photos Endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -827,22 +827,36 @@ paths:
                       format: id
                 - name: page
                   in: query
+                  description: "Page number for offset-based pagination. Cannot be used with cursor pagination (after/before params)"
                   schema:
                       type: integer
                       format: int32
                 - name: per_page
                   in: query
+                  description: "Number of results per page. Default 50, maximum 100"
                   schema:
                       type: integer
                       format: int32
+                      default: 50
+                      maximum: 100
+                - name: after
+                  in: query
+                  description: "Cursor for forward pagination. Comes from X-Next-Cursor header value. Returns results after this cursor position. Cannot be used with 'before' or 'page'"
+                  schema:
+                      type: string
+                - name: before
+                  in: query
+                  description: "Cursor for backward pagination. Comes from X-Prev-Cursor header value. Returns results before this cursor position. Cannot be used with 'after' or 'page'"
+                  schema:
+                      type: string
                 - name: start_date
                   in: query
-                  description: "A unix timestamp to return photos modified on or after the provided value"
+                  description: "A unix timestamp to return photos captured on or after the provided value"
                   schema:
                       type: string
                 - name: end_date
                   in: query
-                  description: "A unix timestamp to return photos modified on or before the provided value"
+                  description: "A unix timestamp to return photos captured on or before the provided value"
                   schema:
                       type: string
                 - name: user_ids
@@ -855,7 +869,7 @@ paths:
                           format: int64
                 - name: group_ids
                   in: query
-                  description: "Filter results to include photos captured by one of these group IDs"
+                  description: "Filter results to include photos captured by users in one of these group IDs"
                   schema:
                       type: array
                       items:
@@ -863,7 +877,7 @@ paths:
                           format: int64
                 - name: tag_ids
                   in: query
-                  description: "Filter results to include photos captured by one of these tag IDs"
+                  description: "Filter results to include photos with one of these tag IDs"
                   schema:
                       type: array
                       items:
@@ -871,7 +885,26 @@ paths:
                           format: int64
             responses:
                 "200":
-                    description: "List of projects sorted by most recent activity first"
+                    description: "List of photos sorted by captured date descending"
+                    headers:
+                        X-Next-Cursor:
+                            description: "Cursor that can be used as an 'after' param to fetch the next page of results. Empty if no more results"
+                            schema:
+                                type: string
+                        X-Prev-Cursor:
+                            description: "Cursor that can be used as a 'before' param to fetch the previous page of results. Empty if no previous results"
+                            schema:
+                                type: string
+                        X-Has-Next:
+                            description: "Indicates whether more results exist after the current page"
+                            schema:
+                                type: string
+                                enum: ["true", "false"]
+                        X-Has-Prev:
+                            description: "Indicates whether results exist before the current page"
+                            schema:
+                                type: string
+                                enum: ["true", "false"]
                     content:
                         application/json:
                             schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1955,12 +1955,12 @@ paths:
                       maximum: 100
                 - name: after
                   in: query
-                  description: "Cursor for forward pagination. Returns results after this cursor position. Cannot be used with 'before' or 'page'"
+                  description: "Cursor for forward pagination. Comes from X-Next-Cursor header value. Returns results after this cursor position. Cannot be used with 'before' or 'page'"
                   schema:
                       type: string
                 - name: before
                   in: query
-                  description: "Cursor for backward pagination. Returns results before this cursor position. Cannot be used with 'after' or 'page'"
+                  description: "Cursor for backward pagination. Comes from X-Prev-Cursor header value. Returns results before this cursor position. Cannot be used with 'after' or 'page'"
                   schema:
                       type: string
                 - name: start_date
@@ -2010,11 +2010,11 @@ paths:
                     description: "List of photos sorted by captured date descending"
                     headers:
                         X-Next-Cursor:
-                            description: "Cursor to fetch the next page of results. Empty if no more results"
+                            description: "Cursor that can be used as an 'after' param to fetch the next page of results. Empty if no more results"
                             schema:
                                 type: string
                         X-Prev-Cursor:
-                            description: "Cursor to fetch the previous page of results. Empty if no previous results"
+                            description: "Cursor that can be used as a 'before' param to fetch the previous page of results. Empty if no previous results"
                             schema:
                                 type: string
                         X-Has-Next:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1941,7 +1941,7 @@ paths:
             parameters:
                 - name: page
                   in: query
-                  description: "Page number for offset-based pagination. Cannot be used with cursor pagination (after/before)"
+                  description: "Page number for offset-based pagination. Cannot be used with cursor pagination (after/before params)"
                   schema:
                       type: integer
                       format: int32

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2034,7 +2034,7 @@ paths:
                                 items:
                                     $ref: "#/components/schemas/Photo"
                 "400":
-                    description: "Bad Request. Returned when both 'after' and 'before' cursors are provided, or when cursor pagination is mixed with offset pagination."
+                    description: "Bad Request"
                     content:
                         application/json:
                             schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1941,14 +1941,28 @@ paths:
             parameters:
                 - name: page
                   in: query
+                  description: "Page number for offset-based pagination. Cannot be used with cursor pagination (after/before)"
                   schema:
                       type: integer
                       format: int32
                 - name: per_page
                   in: query
+                  description: "Number of results per page. Default 50, maximum 100"
                   schema:
                       type: integer
                       format: int32
+                      default: 50
+                      maximum: 100
+                - name: after
+                  in: query
+                  description: "Cursor for forward pagination. Returns results after this cursor position. Cannot be used with 'before' or 'page'"
+                  schema:
+                      type: string
+                - name: before
+                  in: query
+                  description: "Cursor for backward pagination. Returns results before this cursor position. Cannot be used with 'after' or 'page'"
+                  schema:
+                      type: string
                 - name: start_date
                   in: query
                   description: "A unix timestamp to return photos modified on or after the provided value"
@@ -1985,7 +1999,26 @@ paths:
                           format: int64
             responses:
                 "200":
-                    description: "List of projects sorted by most recent activity first"
+                    description: "List of photos sorted by captured date descending"
+                    headers:
+                        X-Next-Cursor:
+                            description: "Cursor to fetch the next page of results. Empty if no more results"
+                            schema:
+                                type: string
+                        X-Prev-Cursor:
+                            description: "Cursor to fetch the previous page of results. Empty if no previous results"
+                            schema:
+                                type: string
+                        X-Has-Next:
+                            description: "Indicates whether more results exist after the current page"
+                            schema:
+                                type: string
+                                enum: ["true", "false"]
+                        X-Has-Prev:
+                            description: "Indicates whether results exist before the current page"
+                            schema:
+                                type: string
+                                enum: ["true", "false"]
                     content:
                         application/json:
                             schema:
@@ -1993,13 +2026,20 @@ paths:
                                 items:
                                     $ref: "#/components/schemas/Photo"
                 "400":
-                    description: "Bad Request"
+                    description: "Bad Request. Returned when both 'after' and 'before' cursors are provided, or when cursor pagination is mixed with offset pagination."
                     content:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/Error"
-                            example:
-                                errors: ["Bad Request"]
+                            examples:
+                                both_cursors:
+                                    summary: Both cursors provided
+                                    value:
+                                        errors: ["Cannot use both 'after' and 'before' parameters"]
+                                mixed_pagination:
+                                    summary: Mixed pagination types
+                                    value:
+                                        errors: ["Cannot use cursor pagination with offset pagination"]
                 "404":
                     description: "Not found"
                     content:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1973,6 +1973,14 @@ paths:
                   description: "A unix timestamp to return photos modified on or before the provided value"
                   schema:
                       type: string
+                - name: project_ids
+                  in: query
+                  description: "Filter results to include photos from one of these project IDs"
+                  schema:
+                      type: array
+                      items:
+                          type: integer
+                          format: int64
                 - name: user_ids
                   in: query
                   description: "Filter results to include photos captured by one of these user IDs"
@@ -3474,6 +3482,11 @@ components:
                             "duplicate",
                         ]
                     example: "processed"
+                status:
+                    type: string
+                    description: "The status of the Photo"
+                    enum: ["active", "deleted"]
+                    example: "active"
                 coordinates:
                     type: array
                     description: "The coordinates where the Photo was captured"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1965,12 +1965,12 @@ paths:
                       type: string
                 - name: start_date
                   in: query
-                  description: "A unix timestamp to return photos modified on or after the provided value"
+                  description: "A unix timestamp to return photos captured on or after the provided value"
                   schema:
                       type: string
                 - name: end_date
                   in: query
-                  description: "A unix timestamp to return photos modified on or before the provided value"
+                  description: "A unix timestamp to return photos captured on or before the provided value"
                   schema:
                       type: string
                 - name: project_ids
@@ -1991,7 +1991,7 @@ paths:
                           format: int64
                 - name: group_ids
                   in: query
-                  description: "Filter results to include photos captured by one of these group IDs"
+                  description: "Filter results to include photos captured by users in one of these group IDs"
                   schema:
                       type: array
                       items:
@@ -1999,7 +1999,7 @@ paths:
                           format: int64
                 - name: tag_ids
                   in: query
-                  description: "Filter results to include photos captured by one of these tag IDs"
+                  description: "Filter results to include photos with one of these tag IDs"
                   schema:
                       type: array
                       items:
@@ -3488,10 +3488,8 @@ components:
                     enum: ["active", "deleted"]
                     example: "active"
                 coordinates:
-                    type: array
+                    $ref: "#/components/schemas/Coordinate"
                     description: "The coordinates where the Photo was captured"
-                    items:
-                        $ref: "#/components/schemas/Coordinate"
                 uris:
                     type: array
                     description: "A list of URIs for the different size variants of the photo."

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3488,8 +3488,9 @@ components:
                     enum: ["active", "deleted"]
                     example: "active"
                 coordinates:
-                    $ref: "#/components/schemas/Coordinate"
                     description: "The coordinates where the Photo was captured"
+                    allOf:
+                        - $ref: "#/components/schemas/Coordinate"
                 uris:
                     type: array
                     description: "A list of URIs for the different size variants of the photo."


### PR DESCRIPTION
This is related to API changes in [this PR](https://github.com/CompanyCam/Company-Cam-API/pull/18622) to add cursor-based pagination to the photos endpoint. While I was at it I also fixed a couple issues the 🤖 pointed out.

Note: this is intentionally not merged yet because the cursor pagination is slow in Mongo (unless we add an index, which we're discussing with Infra) on deep page requests.

Jira subtask: [PLATB-470](https://companycam.atlassian.net/browse/PLATB-470)

[PLATB-470]: https://companycam.atlassian.net/browse/PLATB-470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ