### PR TITLE
Mark company logo as nullable

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3248,6 +3248,7 @@ components:
                     $ref: "#/components/schemas/Address"
                 logo:
                     type: array
+                    nullable: true
                     description: "A list of images for the different variants of the logo"
                     items:
                         $ref: "#/components/schemas/ImageURI"


### PR DESCRIPTION
## Summary

- Adds `nullable: true` to the `logo` property on the `Company` schema

## Context

The v2 `GET /companies/current` endpoint currently returns `"logo": null` when a company has no logo set. The spec did not allow `null` here, causing autogenerated client SDKs (which enforce spec validity on responses) to throw errors during deserialization.

This change makes the spec accurately reflect what the API actually returns, unblocking integrations using SDK generation tools like Dash Restoration.

## Follow-up

A separate change to return `"logo": []` instead of `null` is planned once we have API consumer visibility in place. At that point, `nullable: true` can be removed.

JIRA Ticket: https://companycam.atlassian.net/jira/polaris/projects/ID/ideas/view/6763548?selectedIssue=ID-153

🤖 Generated with [Claude Code](https://claude.com/claude-code)